### PR TITLE
Handle read failure.

### DIFF
--- a/fs-instance.cpp
+++ b/fs-instance.cpp
@@ -203,6 +203,13 @@ namespace ssp {
         }
         else {
             SSP_LOG(log_error) << MY_COORDS  << "Read error; " << ec.message() << ":" << ec.value() << endl;
+	    if( m_socket.is_open() ) {
+		m_state = read_failed;
+	    }
+	    else {
+		m_state = connect_failed;
+	    }
+	    start_timer( 5000 );
         }
     }
     
@@ -233,6 +240,14 @@ namespace ssp {
                 case obtaining_sip_configuration_failed:
                     break ;
                     
+		case read_failed:
+		    if( m_socket.is_open() ) {
+                        m_socket.close();
+		    }
+                    m_state = starting;
+                    start();
+                    break;
+
                 default:
                     bReadAgain = true ;
                     out ="api status\r\n\r\n" ;

--- a/fs-instance.h
+++ b/fs-instance.h
@@ -68,7 +68,8 @@ namespace ssp {
             obtaining_sip_configuration,
             obtaining_sip_configuration_failed,
             querying_status,
-            disconnecting
+            disconnecting,
+	    read_failed
         } ;
         
         void start_timer( unsigned long nMilliseconds ) ;


### PR DESCRIPTION
Handle a situation where a read failure occurs.  This situation will occur if there is an ACL in place that prevents the server running SSP to communicate via mod_event_socket.
